### PR TITLE
Properly parse URL to get PageToken

### DIFF
--- a/functions/-all-functions-in-one/assets/list-numbers.html
+++ b/functions/-all-functions-in-one/assets/list-numbers.html
@@ -615,7 +615,7 @@ async function list_numbers(down) {
 
             if (pagination === "Yes") {
               if (json.nextPageUrl) {
-                Pagetoken = json.nextPageUrl.split("PageToken=")[1];
+                Pagetoken = URL.parse(json.nextPageUrl).searchParams.get("PageToken");
               } else {
                 pageAll = 1;
                 Pagetoken = '';
@@ -923,7 +923,7 @@ async function list_numbers(down) {
 
           if (pagination === "Yes") {
             if (json.nextPageUrl) {
-              Pagetoken = json.nextPageUrl.split("PageToken=")[1];
+              Pagetoken = URL.parse(json.nextPageUrl).searchParams.get("PageToken");
             } else {
               pageAll = 1;
               Pagetoken = "";

--- a/functions/-all-functions-in-one/assets/number-activity.html
+++ b/functions/-all-functions-in-one/assets/number-activity.html
@@ -351,7 +351,7 @@ async function checkUsage(down) {
 
         if (pagination === "Yes" && oneNumber === "") {
           if (json.nextPageUrl) {
-            Pagetoken = json.nextPageUrl.split("PageToken=")[1];
+            Pagetoken = URL.parse(json.nextPageUrl).searchParams.get("PageToken");
           } else {
             pageAll = 1;
           }

--- a/functions/-all-functions-in-one/functions/list_accounts.js
+++ b/functions/-all-functions-in-one/functions/list_accounts.js
@@ -27,7 +27,7 @@ exports.handler = async function (context, event, callback) {
           i += 1;
         }
         if(accounts.nextPageUrl !== undefined){
-          allAccounts[i] = accounts.nextPageUrl.split("PageToken=")[1];
+          allAccounts[i] = URL.parse(accounts.nextPageUrl).searchParams.get("PageToken");
         }
         else {
           allAccounts[i] = "end";

--- a/functions/list-numbers/assets/index.html
+++ b/functions/list-numbers/assets/index.html
@@ -593,7 +593,7 @@ async function list_numbers(down) {
 
             if (pagination === "Yes") {
               if (json.nextPageUrl) {
-                Pagetoken = json.nextPageUrl.split("PageToken=")[1];
+                Pagetoken = URL.parse(json.nextPageUrl).searchParams.get("PageToken");
               } else {
                 pageAll = 1;
                 Pagetoken = '';
@@ -901,7 +901,7 @@ async function list_numbers(down) {
 
           if (pagination === "Yes") {
             if (json.nextPageUrl) {
-              Pagetoken = json.nextPageUrl.split("PageToken=")[1];
+              Pagetoken = URL.parse(json.nextPageUrl).searchParams.get("PageToken");
             } else {
               pageAll = 1;
               Pagetoken = "";

--- a/functions/list-numbers/functions/list_accounts.js
+++ b/functions/list-numbers/functions/list_accounts.js
@@ -27,7 +27,7 @@ exports.handler = async function (context, event, callback) {
           i += 1;
         }
         if(accounts.nextPageUrl !== undefined){
-          allAccounts[i] = accounts.nextPageUrl.split("PageToken=")[1];
+          allAccounts[i] = URL.parse(accounts.nextPageUrl).searchParams.get("PageToken");
         }
         else {
           allAccounts[i] = "end";

--- a/functions/number-activity/assets/index.html
+++ b/functions/number-activity/assets/index.html
@@ -355,7 +355,7 @@ async function checkUsage(down) {
 
         if (pagination === "Yes" && oneNumber === "") {
           if (json.nextPageUrl) {
-            Pagetoken = json.nextPageUrl.split("PageToken=")[1];
+            Pagetoken = URL.parse(json.nextPageUrl).searchParams.get("PageToken");
           } else {
             pageAll = 1;
           }

--- a/functions/transfers/functions/list_accounts.js
+++ b/functions/transfers/functions/list_accounts.js
@@ -27,7 +27,7 @@ exports.handler = async function (context, event, callback) {
           i += 1;
         }
         if(accounts.nextPageUrl !== undefined){
-          allAccounts[i] = accounts.nextPageUrl.split("PageToken=")[1];
+          allAccounts[i] = URL.parse(accounts.nextPageUrl).searchParams.get("PageToken");
         }
         else {
           allAccounts[i] = "end";


### PR DESCRIPTION
Current code fails with URLs like

    "https://api.twilio.com/2010-04-01/Accounts/ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/IncomingPhoneNumbers.json?PageSize=10&PageToken=PAIDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&Page=1"

(with `"&Page=1"` at the end) resulting in `"PAIDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&Page=1"` instead of the expected `"PAIDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"`.
